### PR TITLE
#4 - Fixes duplicated View entries due to Telemetry relationship, Telemetry Stat Updating

### DIFF
--- a/config/install/views.view.ucb_trusted_discovery.yml
+++ b/config/install/views.view.ucb_trusted_discovery.yml
@@ -435,138 +435,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        consumer_site_count:
-          id: consumer_site_count
-          table: ucb_trusted_content_telemetry
-          field: consumer_site_count
-          relationship: telemetry
-          group_type: group
-          admin_label: ''
-          entity_type: ucb_trusted_content_telemetry
-          entity_field: consumer_site_count
-          plugin_id: field
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: false
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: number_integer
-          settings:
-            thousand_separator: ''
-            prefix_suffix: true
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-        total_views:
-          id: total_views
-          table: ucb_trusted_content_telemetry
-          field: total_views
-          relationship: telemetry
-          group_type: group
-          admin_label: ''
-          entity_type: ucb_trusted_content_telemetry
-          entity_field: total_views
-          plugin_id: field
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: number_integer
-          settings:
-            thousand_separator: ''
-            prefix_suffix: true
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
         content_authority:
           id: content_authority
           table: ucb_trusted_content_reference
@@ -695,6 +563,138 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        syndication_consumer_sites:
+          id: syndication_consumer_sites
+          table: ucb_trusted_content_reference
+          field: syndication_consumer_sites
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: ucb_trusted_content_reference
+          entity_field: syndication_consumer_sites
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        syndication_total_views:
+          id: syndication_total_views
+          table: ucb_trusted_content_reference
+          field: syndication_total_views
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: ucb_trusted_content_reference
+          entity_field: syndication_total_views
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
       pager:
         type: mini
         options:
@@ -740,35 +740,35 @@ display:
             format: full_html
           tokenize: false
       sorts:
-        consumer_site_count:
-          id: consumer_site_count
-          table: ucb_trusted_content_telemetry
-          field: consumer_site_count
-          relationship: telemetry
+        syndication_consumer_sites:
+          id: syndication_consumer_sites
+          table: ucb_trusted_content_reference
+          field: syndication_consumer_sites
+          relationship: none
           group_type: group
           admin_label: ''
-          entity_type: ucb_trusted_content_telemetry
-          entity_field: consumer_site_count
+          entity_type: ucb_trusted_content_reference
+          entity_field: syndication_consumer_sites
           plugin_id: standard
-          order: DESC
+          order: ASC
           expose:
-            label: 'Consumer Site Count'
-            field_identifier: consumer_site_count
+            label: 'Consumer Sites Count'
+            field_identifier: syndication_consumer_sites
           exposed: true
-        total_views:
-          id: total_views
-          table: ucb_trusted_content_telemetry
-          field: total_views
-          relationship: telemetry
+        syndication_total_views:
+          id: syndication_total_views
+          table: ucb_trusted_content_reference
+          field: syndication_total_views
+          relationship: none
           group_type: group
           admin_label: ''
-          entity_type: ucb_trusted_content_telemetry
-          entity_field: total_views
+          entity_type: ucb_trusted_content_reference
+          entity_field: syndication_total_views
           plugin_id: standard
-          order: DESC
+          order: ASC
           expose:
             label: 'Total Views'
-            field_identifier: total_views
+            field_identifier: syndication_total_views
           exposed: true
       filters:
         trust_scope:
@@ -1110,16 +1110,6 @@ display:
           relationship: none
           group_type: group
           admin_label: 'Trust Topics'
-          entity_type: ucb_trusted_content_reference
-          plugin_id: standard
-          required: false
-        telemetry:
-          id: telemetry
-          table: ucb_trusted_content_reference
-          field: telemetry
-          relationship: none
-          group_type: group
-          admin_label: Telemetry
           entity_type: ucb_trusted_content_reference
           plugin_id: standard
           required: false


### PR DESCRIPTION
- Swaps the Telemetry relationship fields to use the Syndicated Entity fields instead, so duplicates are removed.
- Correctly updates `Telemetry` stats on the `Trusted Content` Entity. Previously the short-circuit to avoid unnecessary processing on already-existing Syndicated Content Nodes could avoid telemetry stat updates if the Syndicated content was not updated, so numbers would not be accurate

Resolves #4 

Includes changes on `theme` branch `discovery` => https://github.com/CuBoulder/tiamat-theme/pull/1689