### PR TITLE
#8 - Remove Type from user-accessible sort filters

### DIFF
--- a/config/install/views.view.ucb_trusted_discovery.yml
+++ b/config/install/views.view.ucb_trusted_discovery.yml
@@ -1114,58 +1114,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        type:
-          id: type
-          table: ucb_trusted_content_reference
-          field: type
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: ucb_trusted_content_reference
-          entity_field: type
-          plugin_id: in_operator
-          operator: in
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: type_op
-            label: Type
-            description: ''
-            use_operator: false
-            operator: type_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: type
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              developer: '0'
-              architect: '0'
-              site_manager: '0'
-              content_editor: '0'
-              layout_manager: '0'
-              site_owner: '0'
-              edit_own_content: '0'
-              newsletter: '0'
-              webform_editor: '0'
-              webform_submissions_viewer: '0'
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
       filter_groups:
         operator: AND
         groups: {  }


### PR DESCRIPTION
Disables the `Type` user-accessible filter from the Discovery View

Resolves #8 